### PR TITLE
Renaming to authorizationCode and readme updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,16 +4,35 @@
 
 ## **Installation**
 
-### **Step 1: Clone the Repository**
-```bash
-git clone https://github.com/ProjectLibertyLabs/liwl-sdk-android.git
-cd liwl-sdk-android
+### Requirements
+
+Android API version 24 or later and Java 11+.
+
+Here’s what you need in `build.gradle` to target Java 11 byte code for Android and Kotlin plugins respectively.
+
+```groovy
+android {
+    compileOptions {
+        sourceCompatibility JavaVersion.VERSION_11
+        targetCompatibility JavaVersion.VERSION_11
+    }
+
+    kotlinOptions {
+        jvmTarget = '11'
+    }
+}
 ```
 
-### **Step 2: Add Dependencies**
-Add any missing dependencies to your `build.gradle.kts`:
+### Installation
 
-[//]: # (TODO: Figure out if you need to do this or not.)
+
+To install SIWF for Android with [Gradle](https://gradle.org/), simply add the following line to your `build.gradle` file and update the version line to the [latest version](https://github.com/ProjectLibertyLabs/siwf-sdk-android/releases):
+
+```gradle
+dependencies {
+    implementation 'io.projectliberty:siwf:1.0.0'
+}
+```
 
 ## **Usage**
 When you decide to use the SIWF SDK in your own app, follow the steps before for easy integration:
@@ -24,14 +43,14 @@ Use `Siwf.CreateSignInButton` in your UI:
 ```kotlin
     import io.projectliberty.siwf.Siwf
     import io.projectliberty.models.SiwfButtonMode
-    
+
     Siwf.CreateSignInButton(
         mode = SiwfButtonMode.PRIMARY,
         authRequest = authRequest
     )
 ```
 
-### **2️⃣ Handle Authentication Callbacks**
+### **2️⃣ Handle Authorization Callbacks**
 Make sure your `AndroidManifest.xml` includes intent filters:
 
 ```kotlin
@@ -39,39 +58,39 @@ Make sure your `AndroidManifest.xml` includes intent filters:
         android:name="io.projectliberty.helpers.AuthCallbackActivity"
         android:exported="true"
         android:launchMode="singleTask">
-        
+
         <!-- HTTP Callback Example. Requires a Verified App Link: https://developer.android.com/training/app-links/verify-android-applinks -->
         <intent-filter android:autoVerify="true">
-        <action android:name="android.intent.action.VIEW" />
-        <category android:name="android.intent.category.DEFAULT" />
-        <category android:name="android.intent.category.BROWSABLE" />
-        <data
-        android:scheme="http"
-        android:host="localhost"
-        android:port="3000"
-        android:path="/login/callback" />
+          <action android:name="android.intent.action.VIEW" />
+          <category android:name="android.intent.category.DEFAULT" />
+          <category android:name="android.intent.category.BROWSABLE" />
+          <data
+          android:scheme="http"
+          android:host="localhost"
+          android:port="3000"
+          android:path="/login/callback" />
         </intent-filter>
-        
+
         <!-- Custom Schema Support Example -->
         <intent-filter android:autoVerify="true">
-        <action android:name="android.intent.action.VIEW" />
-        <category android:name="android.intent.category.DEFAULT" />
-        <category android:name="android.intent.category.BROWSABLE" />
-        <data
-        android:scheme="siwfdemoapp"
-        android:host="login" />
+          <action android:name="android.intent.action.VIEW" />
+          <category android:name="android.intent.category.DEFAULT" />
+          <category android:name="android.intent.category.BROWSABLE" />
+          <data
+          android:scheme="siwfdemoapp"
+          android:host="login" />
         </intent-filter>
     </activity>
 ```
 
 Then, use the `AuthReceiver` in your main activity:
 ```kotlin
-    var receivedAuthCode by remember { mutableStateOf<String?>(null) }
+    var receivedAuthorizationCode by remember { mutableStateOf<String?>(null) }
     val filter = IntentFilter("io.projectliberty.helpers.AUTH_RESULT")
     val receiver = object : BroadcastReceiver() {
         override fun onReceive(context: Context?, intent: Intent?) {
-            receivedAuthCode = intent?.getStringExtra("authorizationCode")
-            Log.d("HostApp", "✅ Received Auth Code: $receivedAuthCode")
+            receivedAuthorizationCode = intent?.getStringExtra("authorizationCode")
+            Log.d("HostApp", "✅ Received Auth Code: $receivedAuthorizationCode")
         }
     }
 

--- a/app/src/main/java/com/example/app/ContentView.kt
+++ b/app/src/main/java/com/example/app/ContentView.kt
@@ -14,22 +14,22 @@ import io.projectliberty.siwf.Siwf
 /**
  * AuthScreen - Displays sign-in buttons and handles authorization dialog.
  *
- * @param authenticationCode The authorization code received from authentication flow (nullable).
+ * @param authorizationCode The authorization code received from authentication flow (nullable).
  * @param onDismiss Callback to handle dialog dismissal.
  */
 @Composable
-fun ContentView(authenticationCode: String?, onDismiss: () -> Unit) {
+fun ContentView(authorizationCode: String?, onDismiss: () -> Unit) {
     // Show the dialog only if an authorization code is received
-    var showDialog by remember(authenticationCode) { mutableStateOf(authenticationCode != null) }
+    var showDialog by remember(authorizationCode) { mutableStateOf(authorizationCode != null) }
 
-    if (showDialog && authenticationCode != null) {
+    if (showDialog && authorizationCode != null) {
         AlertDialog(
             onDismissRequest = {
                 showDialog = false
                 onDismiss()
             },
             title = { Text("Authorization Code Received") },
-            text = { Text("Code: $authenticationCode") },
+            text = { Text("Code: $authorizationCode") },
             confirmButton = {
                 Button(onClick = {
                     showDialog = false

--- a/app/src/main/java/com/example/app/MainActivity.kt
+++ b/app/src/main/java/com/example/app/MainActivity.kt
@@ -20,15 +20,15 @@ class MainActivity : ComponentActivity() {
         super.onCreate(savedInstanceState)
 
         setContent {
-            var authenticationCode by remember { mutableStateOf<String?>(null) }
+            var authorizationCode by remember { mutableStateOf<String?>(null) }
 
             // Broadcast Receiver to listen for authentication results
             val authReceiver = remember {
                 object : BroadcastReceiver() {
                     override fun onReceive(context: Context?, intent: Intent?) {
                         val receivedCode = intent?.getStringExtra(AuthConstants.AUTH_INTENT_KEY)
-                        authenticationCode = receivedCode
-                        Log.d(TAG, "✅ Authentication code received: $receivedCode")
+                        authorizationCode = receivedCode
+                        Log.d(TAG, "✅ Authorization code received: $receivedCode")
                     }
                 }
             }
@@ -46,8 +46,8 @@ class MainActivity : ComponentActivity() {
             // UI Content
             Surface {
                 ContentView(
-                    authenticationCode = authenticationCode,
-                    onDismiss = { authenticationCode = null }
+                    authorizationCode = authorizationCode,
+                    onDismiss = { authorizationCode = null }
                 )
             }
 

--- a/siwf/build.gradle.kts
+++ b/siwf/build.gradle.kts
@@ -6,7 +6,7 @@ plugins {
 }
 
 android {
-    namespace = "com.example.siwf"
+    namespace = "io.projectliberty.siwf"
     compileSdk = 34
 
     defaultConfig {

--- a/siwf/src/main/java/io/projectliberty/helpers/AuthCallbackActivity.kt
+++ b/siwf/src/main/java/io/projectliberty/helpers/AuthCallbackActivity.kt
@@ -37,14 +37,14 @@ class AuthCallbackActivity : ComponentActivity() {
         Log.d(TAG, "🔗 Deep Link received: $data")
 
         // Extract authorization code from query parameters
-        val authenticationCode = data.getQueryParameter(AuthConstants.AUTH_INTENT_KEY)
-        if (authenticationCode.isNullOrEmpty()) {
+        val authorizationCode = data.getQueryParameter(AuthConstants.AUTH_INTENT_KEY)
+        if (authorizationCode.isNullOrEmpty()) {
             Log.w(TAG, "⚠️ No authorization code found in deep link.")
         } else {
-            Log.d(TAG, "✅ Authorization Code Extracted: $authenticationCode")
+            Log.d(TAG, "✅ Authorization Code Extracted: $authorizationCode")
 
             // Broadcast the auth code to other parts of the app
-            sendAuthenticationCodeBroadcast(authenticationCode)
+            sendAuthorizationCodeBroadcast(authorizationCode)
         }
 
         finish() // Close the activity after handling the deep link
@@ -53,13 +53,13 @@ class AuthCallbackActivity : ComponentActivity() {
     /**
      * Sends a broadcast with the received authorization code.
      *
-     * @param authenticationCode The extracted authorization code.
+     * @param authorizationCode The extracted authorization code.
      */
-    private fun sendAuthenticationCodeBroadcast(authenticationCode: String) {
+    private fun sendAuthorizationCodeBroadcast(authorizationCode: String) {
         Log.i(TAG, "📡 Broadcasting auth code to app components.")
         val broadcastIntent = Intent(AuthConstants.AUTH_RESULT_ACTION).apply {
             setPackage(packageName)
-            putExtra(AuthConstants.AUTH_INTENT_KEY, authenticationCode)
+            putExtra(AuthConstants.AUTH_INTENT_KEY, authorizationCode)
         }
         sendBroadcast(broadcastIntent)
     }

--- a/siwf/src/main/java/io/projectliberty/helpers/AuthConstants.kt
+++ b/siwf/src/main/java/io/projectliberty/helpers/AuthConstants.kt
@@ -4,6 +4,6 @@ package io.projectliberty.helpers
  * Constants used for authentication handling across the sdk and app.
  */
 object AuthConstants {
-    const val AUTH_INTENT_KEY = "authorizationCode"
+    const val AUTH_INTENT_KEY = "authentication"
     const val AUTH_RESULT_ACTION = "io.projectliberty.helpers.AUTH_RESULT"
 }

--- a/siwf/src/main/java/io/projectliberty/helpers/AuthReceiver.kt
+++ b/siwf/src/main/java/io/projectliberty/helpers/AuthReceiver.kt
@@ -14,16 +14,16 @@ class AuthReceiver(private val onAuthReceived: (String?) -> Unit) : BroadcastRec
             return
         }
 
-        val authenticationCode = intent.getStringExtra(AuthConstants.AUTH_INTENT_KEY)
+        val authorizationCode = intent.getStringExtra(AuthConstants.AUTH_INTENT_KEY)
 
-        if (authenticationCode.isNullOrEmpty()) {
+        if (authorizationCode.isNullOrEmpty()) {
             Log.w(TAG, "⚠️ No authorization code found in broadcast intent.")
             return
         }
 
-        Log.d(TAG, "✅ Authorization Code Received: $authenticationCode")
+        Log.d(TAG, "✅ Authorization Code Received: $authorizationCode")
 
         // Trigger the callback with the extracted authorization code
-        onAuthReceived(authenticationCode)
+        onAuthReceived(authorizationCode)
     }
 }


### PR DESCRIPTION
A quick rename to align with the return name. AuthenticationCode -> authorizationCode and updating the readme installation requirements